### PR TITLE
deployable, table works

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/AbstractApiBean.java
@@ -21,6 +21,7 @@ import edu.harvard.iq.dataverse.authorization.groups.GroupServiceBean;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import edu.harvard.iq.dataverse.authorization.users.GuestUser;
 import edu.harvard.iq.dataverse.authorization.users.User;
+import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailServiceBean;
 import edu.harvard.iq.dataverse.engine.command.Command;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
@@ -168,6 +169,9 @@ public abstract class AbstractApiBean {
 
     @EJB
     protected SavedSearchServiceBean savedSearchSvc;
+
+    @EJB
+    protected ConfirmEmailServiceBean confirmEmailSvc;
 
 	@PersistenceContext(unitName = "VDCNet-ejbPU")
 	protected EntityManager em;

--- a/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/BuiltinUsers.java
@@ -8,6 +8,7 @@ import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUserServi
 import edu.harvard.iq.dataverse.authorization.providers.builtin.PasswordEncryption;
 import edu.harvard.iq.dataverse.authorization.users.ApiToken;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailData;
 import edu.harvard.iq.dataverse.util.json.JsonPrinter;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -134,10 +135,18 @@ public class BuiltinUsers extends AbstractApiBean {
             token.setExpireTime(new Timestamp(c.getTimeInMillis()));
             authSvc.save(token);
 
+            ConfirmEmailData confirmEmailData = confirmEmailSvc.createToken(au);
+
             JsonObjectBuilder resp = Json.createObjectBuilder();
             resp.add("user", json(user));
             resp.add("authenticatedUser", jsonForAuthUser(au));
             resp.add("apiToken", token.getTokenString());
+            /**
+             * @todo Remove this once a superuser can retrieve the token via the
+             * admin API. We don't want users to get the confirm email token
+             * except via email.
+             */
+            resp.add("confirmEmailToken", confirmEmailData.getToken());
             
             alr.setInfo("builtinUser:" + user.getUserName() + " authenticatedUser:" + au.getIdentifier() );
             return okResponse(resp);

--- a/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailData.java
+++ b/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailData.java
@@ -105,5 +105,14 @@ public class ConfirmEmailData implements Serializable{
     public void setId(Long id) {
         this.id = id;
     }
-    
+
+    /**
+     * This is only here because it has to be: "The class should have a no-arg,
+     * public or protected constructor." Please use the constructor that takes
+     * arguments.
+     */
+    @Deprecated
+    public ConfirmEmailData() {
+    }
+
 }

--- a/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailPage.java
@@ -27,7 +27,7 @@ import org.hibernate.validator.constraints.NotBlank;
  */
 
 @ViewScoped
-@Named("PasswordResetPage")
+@Named("ConfirmEmailPage")
 public class ConfirmEmailPage implements java.io.Serializable {
 
     private static final Logger logger = Logger.getLogger(ConfirmEmailPage.class.getCanonicalName());

--- a/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/confirmemail/ConfirmEmailServiceBean.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
+import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
@@ -19,6 +20,7 @@ import javax.persistence.TypedQuery;
  * 
  * @author bsilverstein
  */
+@Stateless
 public class ConfirmEmailServiceBean {
     
     private static final Logger logger = Logger.getLogger(ConfirmEmailServiceBean.class.getCanonicalName());
@@ -211,6 +213,12 @@ public class ConfirmEmailServiceBean {
             logger.info("Caught exception trying to delete token " + token + " - " + ex);
             return false;
         }
+    }
+
+    public ConfirmEmailData createToken(AuthenticatedUser au) {
+        ConfirmEmailData confirmEmailData = new ConfirmEmailData(au);
+        em.persist(confirmEmailData);
+        return confirmEmailData;
     }
     
 }    


### PR DESCRIPTION
@bsilverstein95 here are two commits I used to get the code running and to temporarily expose the confirm email token to the end user. Please remove this after you have created an "admin" API for the superuser to retrieve the token so that we can write an API test. Here's how the table looks when it's populated:

![screen shot 2016-07-08 at 3 37 49 pm](https://cloud.githubusercontent.com/assets/21006/16699416/f935e998-4521-11e6-805d-2d8604ee40d2.png)
